### PR TITLE
Feature/8 newsエリア実装

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -18,7 +18,7 @@ block content
   .news
     h2.news__title 新着情報
     nav.news__tab
-      a(href="#all").news__tab-item.news__tab-color すべて
+      a(href="#all").news__tab-item すべて
       a(href="#info").news__tab-item 新着情報
       a(href="#topic").news__tab-item トピック
 

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -18,7 +18,7 @@ block content
   .news
     h2.news__title 新着情報
     nav.news__tab
-      a(href="#all").news__tab-item すべて
+      a(href="#all").news__tab-item.news__tab-color すべて
       a(href="#info").news__tab-item 新着情報
       a(href="#topic").news__tab-item トピック
 
@@ -31,9 +31,21 @@ block content
             .news__contents-item-announce: p お知らせ
           p.news__contents-article 内覧会･体験会｢6月15日(土)｣まずはお電話でご予約ください！！<span class="br">電話:1234-567-890</span>
     #info.news__contents
-      p 新着情報です
+      - var i = 3
+      while i--
+        .news__contents-frame
+            .news__contents-item
+              p.news__contents-item-day 2017.06.11
+              .news__contents-item-announce: p 新着
+            p.news__contents-article 今週の催し物は流しそうめんになりました。
     #topic.news__contents
-      p こちらはトピック
+      - var i = 3
+      while i--
+        .news__contents-frame
+            .news__contents-item
+              p.news__contents-item-day 2017.06.11
+              .news__contents-item-announce: p トピック
+            p.news__contents-article ご利用中の須吾谷さんが散歩中に新種の虫を発見しました！
   .about
     .about__image
     .about__contents

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -18,11 +18,11 @@ block content
   .news
     h2.news__title 新着情報
     ul.news__tab
-      a(href="").news__tab-item.news__tab-color すべて
-      a(href="").news__tab-item 新着情報
-      a(href="").news__tab-item トピック
+      a(href="#all").news__tab-item.news__tab-color すべて
+      a(href="info").news__tab-item 新着情報
+      a(href="topic").news__tab-item トピック
 
-    #All.news__contents
+    #all.news__contents
       - var i = 5
       while i--
         .news__contents-frame

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -17,10 +17,10 @@ block content
 
   .news
     h2.news__title 新着情報
-    ul.news__tab
+    nav.news__tab
       a(href="#all").news__tab-item.news__tab-color すべて
-      a(href="info").news__tab-item 新着情報
-      a(href="topic").news__tab-item トピック
+      a(href="#info").news__tab-item 新着情報
+      a(href="#topic").news__tab-item トピック
 
     #all.news__contents
       - var i = 5

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -18,11 +18,11 @@ block content
   .news
     h2.news__title 新着情報
     ul.news__tab
-      li.news__tab-item.news__tab-color すべて
-      li.news__tab-item 新着情報
-      li.news__tab-item トピック
+      a(href="").news__tab-item.news__tab-color すべて
+      a(href="").news__tab-item 新着情報
+      a(href="").news__tab-item トピック
 
-    .news__contents
+    #All.news__contents
       - var i = 5
       while i--
         .news__contents-frame
@@ -30,7 +30,10 @@ block content
             p.news__contents-item-day 2017.06.11
             .news__contents-item-announce: p お知らせ
           p.news__contents-article 内覧会･体験会｢6月15日(土)｣まずはお電話でご予約ください！！<span class="br">電話:1234-567-890</span>
-
+    #info.news__contents
+      p 新着情報です
+    #topic.news__contents
+      p こちらはトピック
   .about
     .about__image
     .about__contents

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -18,9 +18,9 @@ block content
   .news
     h2.news__title 新着情報
     nav.news__tab
-      a(href="#all").news__tab-item.news__tab-color すべて
-      a(href="#info").news__tab-item 新着情報
-      a(href="#topic").news__tab-item トピック
+      a(href="#all").news__tab-item__tab--active.news__tab-color すべて
+      a(href="#info").news__tab-item__tab--active 新着情報
+      a(href="#topic").news__tab-item__tab--active トピック
 
     #all.news__contents
       - var i = 5

--- a/src/scss/_about.scss
+++ b/src/scss/_about.scss
@@ -5,7 +5,6 @@
 @media (max-width: 600px) {
   .about {
     display: block;
-     //border: 1px solid greenyellow;
     &__image {
       float: left;
       width: 100%;
@@ -14,12 +13,10 @@
       background-position: 60% 100%;
       background-size: 145%;
       margin-bottom: 50px;
-       //border: 1px solid magenta;
     }
     &__contents {
       width: 100%;
       margin-bottom: 60px;
-       //border: 1px solid blue;
       .about__heading {
         width: 85%;
         font-size: 28px;
@@ -27,7 +24,6 @@
         margin: 0 auto;
         margin-bottom: 10px;
         text-align: left;
-         //border: 1px solid red;
       }
       .about__text {
         width: 85%;
@@ -36,7 +32,6 @@
         line-height: 1.5em;
         color: black;
         margin: 0 auto;
-         //border: 1px solid green;
       }
     }
   }
@@ -54,7 +49,6 @@
     @media (min-width: 1201px) {
       width: 100%;
     }
-     //border: 1px solid red;
     &__image {
       position: absolute;
       width: 50%;
@@ -62,7 +56,6 @@
       background-image: url("img/about-img.jpg");
       top: 0;
       left: 50%;
-       //border: 1px solid magenta;
     }
     &__contents {
       position: absolute;
@@ -72,7 +65,6 @@
       color: black;
       top: 0;
       left: 0;
-       //border: 1px solid blue;
       .about__heading {
         position: absolute;
         font-size: 30px;
@@ -92,7 +84,6 @@
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-         //border: 1px solid green;
       }
     }
   }

--- a/src/scss/_news.scss
+++ b/src/scss/_news.scss
@@ -36,10 +36,13 @@
           background-color: #c30d23;
           color: #fff;
         }
+        &:target {
+          display: block;
+        }
       }
     }
     &__contents {
-      display: block;
+      display: none;
       width: 90%;
       height: 200px;
       margin: 0 auto;
@@ -85,6 +88,9 @@
         font-size: 17px;
         font-weight: bold;
         line-height: 1.5em;
+      }
+      &:target {
+        display: block;
       }
     }
   }
@@ -135,7 +141,7 @@
       }
     }
     &__contents {
-      display: block;
+      display: none;
       width: 1000px;
       height: 380px;
       margin: 0 auto;
@@ -179,6 +185,9 @@
         padding: 13px 0 13px 15px;
         width: 700px;
         height: 51px;
+      }
+      &:target {
+        display: block;
       }
     }
   }

--- a/src/scss/_news.scss
+++ b/src/scss/_news.scss
@@ -30,6 +30,7 @@
         border-right: 5px solid #fafafa;
         height: 50px;
         background-color: #f2f2f2;
+        text-decoration: none;
         &:first-child {
           font-weight: bold;
           background-color: #c30d23;
@@ -126,6 +127,7 @@
         border-right: 10px solid #fafafa;
         height: 45px;
         background-color: #f2f2f2;
+        text-decoration: none;
       }
       &-color {
         background-color: #c30d23;

--- a/src/scss/_news.scss
+++ b/src/scss/_news.scss
@@ -22,7 +22,7 @@
       width: 91%;
       margin: 0 auto;
       list-style: none;
-      &-item {
+      &-item__tab--active {
         font-size: 13px;
         color: #6a6a6a;
         display: table-cell;
@@ -121,7 +121,7 @@
       width: 1000px;
       margin: 0 auto;
       margin-bottom: 40px;
-      &-item {
+      &-item__tab--active {
         font-size: 13px;
         font-weight: bold;
         color: #6a6a6a;

--- a/src/scss/_news.scss
+++ b/src/scss/_news.scss
@@ -106,9 +106,6 @@
     position: relative;
     background-color: #fafafa;
     border: 1px solid #fafafa;
-    @media (min-width: 1201px) {
-      width: 100%;
-    }
     &__title {
       width: 100%;
       height: 43px;
@@ -190,5 +187,10 @@
         display: block;
       }
     }
+  }
+}
+@media (min-width: 1201px) {
+  .news {
+    width: 100%;
   }
 }

--- a/src/scss/_news.scss
+++ b/src/scss/_news.scss
@@ -22,7 +22,6 @@
       width: 91%;
       margin: 0 auto;
       list-style: none;
-       //border: 1px solid green;
       &-item {
         font-size: 13px;
         color: #6a6a6a;
@@ -53,14 +52,12 @@
         width: 100%;
         height: 140px;
         margin-top: 10px;
-         //border: 1px solid aqua;
       }
       &-item {
         display: flex;
         width: 95%;
         height: 40px;
         margin: 0 auto;
-         //border: 1px solid limegreen;
         &-day {
           margin-top: 0;
           font-size: 15px;
@@ -77,7 +74,6 @@
           color: white;
           font-weight: bold;
           text-align: center;
-           //border: 2px solid lightblue;
         }
       }
       &-article {
@@ -88,7 +84,6 @@
         font-size: 17px;
         font-weight: bold;
         line-height: 1.5em;
-         //border: 1px solid pink;
       }
     }
   }
@@ -114,7 +109,6 @@
       color: #6a6a6a;
       text-align: center;
       font-weight: bold;
-       //border: 1px solid green;
     }
     &__tab {
       display: table;
@@ -123,7 +117,6 @@
       width: 1000px;
       margin: 0 auto;
       margin-bottom: 40px;
-       //border: 1px solid green;
       &-item {
         font-size: 13px;
         font-weight: bold;
@@ -146,18 +139,15 @@
       margin: 0 auto;
       background: #fff;
       overflow: auto;
-       //border: 1px solid purple;
       &-frame {
         display: flex;
         width: 100%;
         height: 80px;
         margin-bottom: 37px;
-         //border: 1px solid aqua;
       }
       &-item {
         display: flex;
         width: 290px;
-         //border: 1px solid limegreen;
         &-day {
           margin-top: 0;
           font-size: 15px;
@@ -187,7 +177,6 @@
         padding: 13px 0 13px 15px;
         width: 700px;
         height: 51px;
-         //border: 1px solid pink;
       }
     }
   }

--- a/src/scss/_news.scss
+++ b/src/scss/_news.scss
@@ -99,11 +99,14 @@
 
 @media (min-width: 601px) {
   .news {
-    width: 100%;
+    width: 1200px;
     height: 762px;
     position: relative;
     background-color: #fafafa;
     border: 1px solid #fafafa;
+    @media (min-width: 1201px) {
+      width: 100%;
+    }
     &__title {
       width: 100%;
       height: 43px;


### PR DESCRIPTION
#8 
`width1201px`以下にて`width1200px`に固定
`news__contents`にidを付与して.`news__tab`の切り替えを実装
それに伴い`news__contents`の内容を追加しました。
※bag 切り替えた際に現在のコードですとタブ色の切り替えが難しい為
　　　JSを用いらないと厳しそうとゆう判断で一時断念