### PR TITLE
Fix/54 #54~57の修正

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -22,7 +22,7 @@ $('.js-tab-trg').on('click', function () {
 
   $('.js-tab-trg').removeClass('tab__item--active');
   $(this).addClass('tab__item--active');
-  $('.js-tab-content').removeClass('contents--active');
-  $('.js-tab-content--' + targetId).addClass('contents--active');
+  $('.js-tab-content').removeClass('tab-content--active');
+  $('.js-tab-content--' + targetId).addClass('tab-content--active');
   return false;
 });

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -6,11 +6,11 @@ $('.js-nav-burger').on('click', function () {
   return false;
 });
 
-$(document).on('click', function (event) {
+$(document).on('click touchstart', function (event) {
   $('.js-nav').removeClass('active');
 });
 
-$('.js-nav').on('click', function (event) {
+$('.js-nav').on('click touchstart', function (event) {
   event.stopPropagation();
 });
 

--- a/src/scss/_facility.scss
+++ b/src/scss/_facility.scss
@@ -1,8 +1,8 @@
 .facility-map {
+  width: 100%;
   margin-top: 50px;
   height: 150px;
   @include desktop() {
-    width: 100%;
     vertical-align: bottom;
     height: 300px;
     pointer-events: none;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/earlyaccess/notosansjp.css);
+@import url(//fonts.googleapis.com/earlyaccess/notosansjp.css);
 @import "variable";
 @import "mixin";
 


### PR DESCRIPTION
## firefox fontcss 混在アクティブコンテンツのブロック bug
#54 
- notosans jpのimport URLを書き換えて修正
## js タブの切り替えが無効になっている。 bug
#55 
- トリガー名を修正 動作確認済み
## safari Ihone7 GoogleMapの不具合 bug
#56
- facility/scss .facility-mapの `width: 100%` を共になるように移動 
## ihone7 メニューが閉じない (実機のみ確認) bug
#57 
- touchstartを追記 ihone7のsafariにて動作確認済み
```$(document).on('click touchstart', function (event) {
  $('.js-nav').removeClass('active');
});
```